### PR TITLE
Color Picker updates

### DIFF
--- a/Resources/EditorData/AtomicEditor/editor/ui/colorchooser.tb.txt
+++ b/Resources/EditorData/AtomicEditor/editor/ui/colorchooser.tb.txt
@@ -1,13 +1,13 @@
-TBLayout: axis: y, distribution: gravity, position: left	
+TBLayout: axis: y, distribution: gravity, position: left
 	lp: min-width: 300
 	TBLayout: axis: x, distribution: gravity
 		TBColorWheel: id: colorwheel, skin: HSVSkin
 				lp: width: 256, height: 256
 		TBSlider: id: lslider, axis: y, min: 0, max: 255, value: 128
 	TBLayout: axis: x, distribution: available, gravity: left right
-		TBColorWidget: id: colorold, color: blue, skin: Checkerboard
+		TBColorWidget: id: colornew, color: blue, skin: Checkerboard
 				lp: width: 128, height: 64, max-width: 150, max-height: 80
-		TBColorWidget: id: colornew, color: red, skin: Checkerboard
+		TBColorWidget: id: colorold, color: red, skin: Checkerboard
 				lp: width: 128, height: 64, max-width: 150, max-height: 80
 	TBLayout: axis: y, distribution: gravity
 		TBLayout: axis: x, distribution: gravity
@@ -35,5 +35,5 @@ TBLayout: axis: y, distribution: gravity, position: left
 				font: size: 16
 	TBSeparator: gravity: left right, skin: AESeparator
 	TBLayout:
-		TBButton: text: Cancel, id: ccancelbutton
 		TBButton: text: OK, id: cokbutton
+		TBButton: text: Cancel, id: ccancelbutton

--- a/Script/AtomicEditor/ui/frames/inspector/InspectorUtils.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/InspectorUtils.ts
@@ -84,6 +84,21 @@ class InspectorUtils {
 
   }
 
+  static createColorWidget():Atomic.UIColorWidget {
+
+    var colorWidget = new Atomic.UIColorWidget();
+    colorWidget.id = "colorfield";
+
+    var lp = new Atomic.UILayoutParams();
+    lp.width = 160;
+    lp.height = 24;
+    colorWidget.layoutParams = lp;
+
+    return colorWidget;
+
+  }
+
+
   static createAttrEditField(name:string, parent:Atomic.UIWidget):Atomic.UIEditField {
 
     var attrLayout = new Atomic.UILayout();
@@ -154,6 +169,34 @@ class InspectorUtils {
 
   }
 
+  static createAttrColorFieldWithSelectButton(name:string, parent:Atomic.UIWidget):{colorWidget:Atomic.UIColorWidget, selectButton:Atomic.UIButton} {
+
+    var attrLayout = new Atomic.UILayout();
+    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
+
+    if (name) {
+      var _name = InspectorUtils.createAttrName(name);
+      attrLayout.addChild(_name);
+    }
+
+    var fieldLayout = new Atomic.UILayout();
+    fieldLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
+
+    var colorWidget = InspectorUtils.createColorWidget();
+
+    var selectButton = new Atomic.UIButton();
+    selectButton.text = "...";
+    selectButton.fontDescription = InspectorUtils.attrFontDesc;
+
+    fieldLayout.addChild(colorWidget);
+    fieldLayout.addChild(selectButton);
+
+    attrLayout.addChild(fieldLayout);
+    parent.addChild(attrLayout);
+
+    return {colorWidget:colorWidget, selectButton:selectButton};
+
+  }
 
   // "static constructor"
   static attrFontDesc:Atomic.UIFontDescription;

--- a/Source/Atomic/UI/UIColorWidget.cpp
+++ b/Source/Atomic/UI/UIColorWidget.cpp
@@ -57,11 +57,31 @@ bool UIColorWidget::OnEvent(const tb::TBWidgetEvent &ev)
     return UIWidget::OnEvent(ev);
 }
 
-void UIColorWidget::SetColor ( const String &name )
+void UIColorWidget::SetColorString( const String &name )
 {
      if (!widget_)
         return;
     ((TBColorWidget*) widget_)->SetColor(name.CString());
+}
+
+void UIColorWidget::SetColor(const Color& color)
+{
+    if (!widget_)
+        return;
+
+    ((TBColorWidget*)widget_)->SetColor(color.r_ * 255.0f, color.g_ * 255.0f, color.b_ * 255.0f, color.a_ * 255.0f);
+}
+
+Color UIColorWidget::GetColor() const
+{
+    if (!widget_)
+        return Color::BLACK;
+
+    const TBColor& color = ((TBColorWidget*)widget_)->GetColor();
+    float alpha = ((TBColorWidget*)widget_)->GetAlpha();
+
+    return Color(color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, alpha / 255.0f);
+
 }
 
 void UIColorWidget::SetAlpha ( float value )

--- a/Source/Atomic/UI/UIColorWidget.h
+++ b/Source/Atomic/UI/UIColorWidget.h
@@ -40,7 +40,14 @@ public:
     UIColorWidget(Context* context, bool createWidget = true);
     virtual ~UIColorWidget();
 
-    void SetColor ( const String &name );
+    /// Set color from a Color value
+    void SetColor(const Color& color);
+
+    /// Set color from hex string
+    void SetColorString(const String &name);
+
+    Color GetColor() const;
+
     void SetAlpha ( float value );
 
 protected:

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
@@ -35,7 +35,7 @@ namespace tb {
 
 // == TBColorWidget =======================================
 
-TBColorWidget::TBColorWidget() : color_(), alpha_ ( 1.0)
+TBColorWidget::TBColorWidget() : color_(), alpha_ ( 1.0f)
 {
 }
 
@@ -44,6 +44,14 @@ void TBColorWidget::SetColor ( const char *name )
 	if ( name )
   	 color_.SetFromString(name, strlen(name));
      
+    InvalidateSkinStates();
+    Invalidate();
+}
+
+void TBColorWidget::SetColor(float r, float g, float b, float a)
+{
+    color_.Set(TBColor(r, g, b, a));
+
     InvalidateSkinStates();
     Invalidate();
 }

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
@@ -43,8 +43,14 @@ public:
 
     TBColorWidget();
 
-    virtual void SetColor ( const char * );
-    virtual void SetAlpha ( float );
+    void SetColor ( const char * );
+    void SetColor (float r, float g, float b, float a);
+
+    void SetAlpha ( float );
+
+    const TBColor& GetColor() const { return color_; }
+    float GetAlpha() const { return alpha_; }
+
     virtual void OnInflate(const INFLATE_INFO &info);
     virtual void OnPaint(const PaintProps &paint_props);
 


### PR DESCRIPTION
Remove the inline selects from color attr editor and use UIColorWidget instead, add Color setter and getter for UIColorWidget (+2 squashed commit)

Squashed commit:

[60aeef6] Support preview of color choice across selected objects, handle closing the window and not hitting ok/cancel, flip ok/cancel to be consistent with other dialogs, swap new/old color widgets, a few cleanups

[61da139] Color Chooser updates